### PR TITLE
Deprecation of ultradns soap

### DIFF
--- a/ultradns-rest/src/main/java/denominator/ultradns/iterator/GroupGeoRecordByNameTypeCustomIterator.java
+++ b/ultradns-rest/src/main/java/denominator/ultradns/iterator/GroupGeoRecordByNameTypeCustomIterator.java
@@ -129,8 +129,8 @@ public final class GroupGeoRecordByNameTypeCustomIterator implements Iterator<Re
   }
 
   /**
-   * Returns DirectionalGroup which contains the group name & it's territories
-   * for a particular Owner name, record type & geo group.
+   * Returns DirectionalGroup which contains the group name and it's territories
+   * for a particular Owner name, record type and geo group.
    * @param zone name of the zone
    * @param hostName owner name or directional pool name
    * @param rrType resource record record type
@@ -220,7 +220,7 @@ public final class GroupGeoRecordByNameTypeCustomIterator implements Iterator<Re
     }
 
     /**
-     * Construct a custom iterator from directional record iterator & zone name.
+     * Construct a custom iterator from directional record iterator and zone name.
      * @param sortedIterator only contains records with the same.
      */
     public Iterator<ResourceRecordSet<?>> create(Iterator<DirectionalRecord> sortedIterator, String name,

--- a/ultradns-rest/src/main/java/denominator/ultradns/service/UltraDNSRestGeoResourceRecordSetApi.java
+++ b/ultradns-rest/src/main/java/denominator/ultradns/service/UltraDNSRestGeoResourceRecordSetApi.java
@@ -249,7 +249,7 @@ public final class UltraDNSRestGeoResourceRecordSetApi implements GeoResourceRec
 
   /**
    * This method will update Geo Records for a combination
-   * of owner, resource type & group.
+   * of owner, resource type and group.
    * @param rrset contains the {@code rdata} elements ensure exist. If {@link
    *              ResourceRecordSet#ttl() ttl} is not present, zone default is used.
    */

--- a/ultradns-rest/src/main/java/denominator/ultradns/service/UltraDNSRestGeoSupport.java
+++ b/ultradns-rest/src/main/java/denominator/ultradns/service/UltraDNSRestGeoSupport.java
@@ -17,7 +17,7 @@ import org.apache.commons.lang.StringUtils;
 import org.apache.log4j.Logger;
 
 /**
- * Support class to all Geo Services & Directional pool record related activity.
+ * Support class to all Geo Services and Directional pool record related activity.
  * Provide a hierarchical structure of all available regions.
  */
 @Module(injects = UltraDNSRestGeoResourceRecordSetApi.Factory.class, complete = false)

--- a/ultradns-rest/src/main/java/denominator/ultradns/service/UltraDNSRestResourceRecordSetApi.java
+++ b/ultradns-rest/src/main/java/denominator/ultradns/service/UltraDNSRestResourceRecordSetApi.java
@@ -127,7 +127,7 @@ public final class UltraDNSRestResourceRecordSetApi implements denominator.Resou
 
   /**
    * This method will update Records for a combination
-   * of owner, resource type & group.
+   * of owner, resource type and group.
    * @param rrset If {@link
    *              ResourceRecordSet#ttl() ttl} is not present, zone default is used.
    */

--- a/ultradns-rest/src/main/java/denominator/ultradns/service/UltraDNSRestZoneApi.java
+++ b/ultradns-rest/src/main/java/denominator/ultradns/service/UltraDNSRestZoneApi.java
@@ -89,7 +89,7 @@ public final class UltraDNSRestZoneApi implements denominator.ZoneApi {
   }
 
   /**
-   * Add or update a zone with email & ttl.
+   * Add or update a zone with email and ttl.
    * @param zone Zone Object
    * @return zone name of the Zone
    */

--- a/ultradns/src/main/java/denominator/ultradns/GroupByRecordNameAndTypeIterator.java
+++ b/ultradns/src/main/java/denominator/ultradns/GroupByRecordNameAndTypeIterator.java
@@ -12,6 +12,18 @@ import denominator.ultradns.UltraDNS.Record;
 import static denominator.common.Util.peekingIterator;
 import static denominator.common.Util.toMap;
 
+/**
+ * @deprecated UltraDNS SOAP API is close to EOL (End of Life),
+ * use {@link denominator.ultradns.iterator.GroupByRecordNameAndTypeCustomIterator} instead.
+ *
+ * <p>
+ * UltraDNS-REST provider details :
+ * <ul>
+ * <li>Provider name : ultradnsrest</li>
+ * <li>URL : https://restapi.ultradns.com/v2</li>
+ * </ul>
+ */
+@Deprecated
 class GroupByRecordNameAndTypeIterator implements Iterator<ResourceRecordSet<?>> {
 
   private final PeekingIterator<Record> peekingIterator;

--- a/ultradns/src/main/java/denominator/ultradns/GroupGeoRecordByNameTypeIterator.java
+++ b/ultradns/src/main/java/denominator/ultradns/GroupGeoRecordByNameTypeIterator.java
@@ -20,7 +20,18 @@ import static denominator.common.Util.toMap;
  * However, there are special cases where this can produce multiple. For example, {@link
  * DirectionalPool.RecordType#IPV4} and {@link DirectionalPool.RecordType#IPV6} emit both address
  * ({@code A} or {@code AAAA}) and {@code CNAME} records.
+ *
+ * @deprecated UltraDNS SOAP API is close to EOL (End of Life),
+ * use {@link denominator.ultradns.iterator.GroupGeoRecordByNameTypeCustomIterator} instead.
+ *
+ * <p>
+ * UltraDNS-REST provider details :
+ * <ul>
+ * <li>Provider name : ultradnsrest</li>
+ * <li>URL : https://restapi.ultradns.com/v2</li>
+ * </ul>
  */
+@Deprecated
 class GroupGeoRecordByNameTypeIterator implements Iterator<ResourceRecordSet<?>> {
 
   private final Map<String, Geo> cache = new LinkedHashMap<String, Geo>();

--- a/ultradns/src/main/java/denominator/ultradns/InvalidatableAccountIdSupplier.java
+++ b/ultradns/src/main/java/denominator/ultradns/InvalidatableAccountIdSupplier.java
@@ -8,8 +8,19 @@ import denominator.Credentials;
 
 /**
  * gets the last account id, expiring if the url or credentials changed
+ * similar to guava MemoizingSupplier
+ *
+ * @deprecated UltraDNS SOAP API is close to EOL (End of Life),
+ * use {@link denominator.ultradns.service.auth.InvalidatableTokenProvider} instead.
+ *
+ * <p>
+ * UltraDNS-REST provider details :
+ * <ul>
+ * <li>Provider name : ultradnsrest</li>
+ * <li>URL : https://restapi.ultradns.com/v2</li>
+ * </ul>
  */
-// similar to guava MemoizingSupplier
+@Deprecated
 @Singleton
 class InvalidatableAccountIdSupplier {
 

--- a/ultradns/src/main/java/denominator/ultradns/NetworkStatusReadable.java
+++ b/ultradns/src/main/java/denominator/ultradns/NetworkStatusReadable.java
@@ -5,6 +5,18 @@ import javax.inject.Inject;
 import denominator.CheckConnection;
 import denominator.ultradns.UltraDNS.NetworkStatus;
 
+/**
+ * @deprecated UltraDNS SOAP API is close to EOL (End of Life),
+ * use {@link denominator.ultradns.service.NetworkConnection} instead.
+ *
+ * <p>
+ * UltraDNS-REST provider details :
+ * <ul>
+ * <li>Provider name : ultradnsrest</li>
+ * <li>URL : https://restapi.ultradns.com/v2</li>
+ * </ul>
+ */
+@Deprecated
 class NetworkStatusReadable implements CheckConnection {
 
   private final UltraDNS api;

--- a/ultradns/src/main/java/denominator/ultradns/UltraDNS.java
+++ b/ultradns/src/main/java/denominator/ultradns/UltraDNS.java
@@ -11,6 +11,19 @@ import feign.Headers;
 import feign.Param;
 import feign.RequestLine;
 
+/**
+ * @deprecated UltraDNS SOAP API is close to EOL (End of Life),
+ * use {@link denominator.ultradns.service.integration.UltraDNSRest} instead.
+ *
+ * <p>
+ * UltraDNS-REST provider details :
+ * <ul>
+ * <li>Provider name : ultradnsrest</li>
+ * <li>URL : https://restapi.ultradns.com/v2</li>
+ * </ul>
+ */
+//@Deprecated
+@Deprecated
 @Headers("Content-Type: application/xml")
 interface UltraDNS {
 

--- a/ultradns/src/main/java/denominator/ultradns/UltraDNSContentHandlers.java
+++ b/ultradns/src/main/java/denominator/ultradns/UltraDNSContentHandlers.java
@@ -27,7 +27,17 @@ import static denominator.common.Util.split;
 
 /**
  * all decoders use {@code .endsWith} as a cheap way to strip out namespaces, such as {@code ns2:}.
+ *
+ * @deprecated UltraDNS SOAP API is close to EOL (End of Life).
+ *
+ * <p>
+ * UltraDNS-REST provider details :
+ * <ul>
+ * <li>Provider name : ultradnsrest</li>
+ * <li>URL : https://restapi.ultradns.com/v2</li>
+ * </ul>
  */
+@Deprecated
 class UltraDNSContentHandlers {
 
   static final SimpleDateFormat iso8601 = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'");

--- a/ultradns/src/main/java/denominator/ultradns/UltraDNSErrorDecoder.java
+++ b/ultradns/src/main/java/denominator/ultradns/UltraDNSErrorDecoder.java
@@ -17,6 +17,18 @@ import static denominator.common.Util.slurp;
 import static feign.Util.UTF_8;
 import static java.lang.String.format;
 
+/**
+ * @deprecated UltraDNS SOAP API is close to EOL (End of Life),
+ * use {@link denominator.ultradns.service.decoder.UltraDNSRestErrorDecoder} instead.
+ *
+ * <p>
+ * UltraDNS-REST provider details :
+ * <ul>
+ * <li>Provider name : ultradnsrest</li>
+ * <li>URL : https://restapi.ultradns.com/v2</li>
+ * </ul>
+ */
+@Deprecated
 class UltraDNSErrorDecoder implements ErrorDecoder {
 
   private final Decoder decoder;

--- a/ultradns/src/main/java/denominator/ultradns/UltraDNSException.java
+++ b/ultradns/src/main/java/denominator/ultradns/UltraDNSException.java
@@ -2,6 +2,18 @@ package denominator.ultradns;
 
 import feign.FeignException;
 
+/**
+ * @deprecated UltraDNS SOAP API is close to EOL (End of Life),
+ * use {@link denominator.ultradns.exception.UltraDNSRestException} instead.
+ *
+ * <p>
+ * UltraDNS-REST provider details :
+ * <ul>
+ * <li>Provider name : ultradnsrest</li>
+ * <li>URL : https://restapi.ultradns.com/v2</li>
+ * </ul>
+ */
+@Deprecated
 class UltraDNSException extends FeignException {
 
   /**

--- a/ultradns/src/main/java/denominator/ultradns/UltraDNSFilters.java
+++ b/ultradns/src/main/java/denominator/ultradns/UltraDNSFilters.java
@@ -7,6 +7,17 @@ import denominator.ultradns.UltraDNS.Record;
 
 import static denominator.common.Preconditions.checkNotNull;
 
+/**
+ * @deprecated UltraDNS SOAP API is close to EOL (End of Life).
+ *
+ * <p>
+ * UltraDNS-REST provider details :
+ * <ul>
+ * <li>Provider name : ultradnsrest</li>
+ * <li>URL : https://restapi.ultradns.com/v2</li>
+ * </ul>
+ */
+@Deprecated
 final class UltraDNSFilters {
 
   private UltraDNSFilters() {

--- a/ultradns/src/main/java/denominator/ultradns/UltraDNSFormEncoder.java
+++ b/ultradns/src/main/java/denominator/ultradns/UltraDNSFormEncoder.java
@@ -14,6 +14,17 @@ import feign.codec.Encoder;
 import static denominator.common.Util.join;
 import static java.lang.String.format;
 
+/**
+ * @deprecated UltraDNS SOAP API is close to EOL (End of Life).
+ *
+ * <p>
+ * UltraDNS-REST provider details :
+ * <ul>
+ * <li>Provider name : ultradnsrest</li>
+ * <li>URL : https://restapi.ultradns.com/v2</li>
+ * </ul>
+ */
+@Deprecated
 class UltraDNSFormEncoder implements Encoder {
 
   private static final String

--- a/ultradns/src/main/java/denominator/ultradns/UltraDNSGeoResourceRecordSetApi.java
+++ b/ultradns/src/main/java/denominator/ultradns/UltraDNSGeoResourceRecordSetApi.java
@@ -27,6 +27,18 @@ import static denominator.common.Util.nextOrNull;
 import static denominator.common.Util.toMap;
 import static denominator.model.ResourceRecordSets.nameAndTypeEqualTo;
 
+/**
+ * @deprecated UltraDNS SOAP API is close to EOL (End of Life),
+ * use {@link denominator.ultradns.service.UltraDNSRestGeoResourceRecordSetApi} instead.
+ *
+ * <p>
+ * UltraDNS-REST provider details :
+ * <ul>
+ * <li>Provider name : ultradnsrest</li>
+ * <li>URL : https://restapi.ultradns.com/v2</li>
+ * </ul>
+ */
+@Deprecated
 final class UltraDNSGeoResourceRecordSetApi implements GeoResourceRecordSetApi {
 
   private static final Filter<ResourceRecordSet<?>> IS_GEO = new Filter<ResourceRecordSet<?>>() {

--- a/ultradns/src/main/java/denominator/ultradns/UltraDNSGeoSupport.java
+++ b/ultradns/src/main/java/denominator/ultradns/UltraDNSGeoSupport.java
@@ -8,6 +8,18 @@ import javax.inject.Named;
 import dagger.Module;
 import dagger.Provides;
 
+/**
+ * @deprecated UltraDNS SOAP API is close to EOL (End of Life),
+ * use {@link denominator.ultradns.service.UltraDNSRestGeoSupport} instead.
+ *
+ * <p>
+ * UltraDNS-REST provider details :
+ * <ul>
+ * <li>Provider name : ultradnsrest</li>
+ * <li>URL : https://restapi.ultradns.com/v2</li>
+ * </ul>
+ */
+@Deprecated
 @Module(injects = UltraDNSGeoResourceRecordSetApi.Factory.class, complete = false)
 public class UltraDNSGeoSupport {
 

--- a/ultradns/src/main/java/denominator/ultradns/UltraDNSProvider.java
+++ b/ultradns/src/main/java/denominator/ultradns/UltraDNSProvider.java
@@ -41,6 +41,18 @@ import feign.sax.SAXDecoder;
 
 import static dagger.Provides.Type.SET;
 
+/**
+ * @deprecated UltraDNS SOAP API is close to EOL (End of Life),
+ * use {@link UltraDNSRestProvider} instead.
+ *
+ * <p>
+ * UltraDNS-REST provider details :
+ * <ul>
+ * <li>Provider name : ultradnsrest</li>
+ * <li>URL : https://restapi.ultradns.com/v2</li>
+ * </ul>
+ */
+@Deprecated
 public class UltraDNSProvider extends BasicProvider {
 
   private final String url;

--- a/ultradns/src/main/java/denominator/ultradns/UltraDNSResourceRecordSetApi.java
+++ b/ultradns/src/main/java/denominator/ultradns/UltraDNSResourceRecordSetApi.java
@@ -17,6 +17,19 @@ import static denominator.common.Preconditions.checkNotNull;
 import static denominator.common.Util.nextOrNull;
 import static denominator.common.Util.toMap;
 
+
+/**
+ * @deprecated UltraDNS SOAP API is close to EOL (End of Life),
+ * use {@link denominator.ultradns.service.UltraDNSRestResourceRecordSetApi} instead.
+ *
+ * <p>
+ * UltraDNS-REST provider details :
+ * <ul>
+ * <li>Provider name : ultradnsrest</li>
+ * <li>URL : https://restapi.ultradns.com/v2</li>
+ * </ul>
+ */
+@Deprecated
 final class UltraDNSResourceRecordSetApi implements denominator.ResourceRecordSetApi {
 
   private static final int DEFAULT_TTL = 300;

--- a/ultradns/src/main/java/denominator/ultradns/UltraDNSRoundRobinPoolApi.java
+++ b/ultradns/src/main/java/denominator/ultradns/UltraDNSRoundRobinPoolApi.java
@@ -9,6 +9,17 @@ import static denominator.ResourceTypeToValue.lookup;
 import static denominator.common.Preconditions.checkNotNull;
 import static denominator.common.Preconditions.checkState;
 
+/**
+ * @deprecated UltraDNS SOAP API is close to EOL (End of Life).
+ *
+ * <p>
+ * UltraDNS-REST provider details :
+ * <ul>
+ * <li>Provider name : ultradnsrest</li>
+ * <li>URL : https://restapi.ultradns.com/v2</li>
+ * </ul>
+ */
+@Deprecated
 class UltraDNSRoundRobinPoolApi {
 
   private final UltraDNS api;

--- a/ultradns/src/main/java/denominator/ultradns/UltraDNSTarget.java
+++ b/ultradns/src/main/java/denominator/ultradns/UltraDNSTarget.java
@@ -16,6 +16,18 @@ import static denominator.common.Preconditions.checkNotNull;
 import static feign.Util.UTF_8;
 import static java.lang.String.format;
 
+/**
+ * @deprecated UltraDNS SOAP API is close to EOL (End of Life),
+ * use {@link denominator.ultradns.service.auth.UltraDNSRestTarget} instead.
+ *
+ * <p>
+ * UltraDNS-REST provider details :
+ * <ul>
+ * <li>Provider name : ultradnsrest</li>
+ * <li>URL : https://restapi.ultradns.com/v2</li>
+ * </ul>
+ */
+@Deprecated
 class UltraDNSTarget implements Target<UltraDNS> {
 
     static final String SOAP_TEMPLATE = "<?xml version=\"1.0\"?>\n"

--- a/ultradns/src/main/java/denominator/ultradns/UltraDNSZoneApi.java
+++ b/ultradns/src/main/java/denominator/ultradns/UltraDNSZoneApi.java
@@ -13,6 +13,18 @@ import denominator.ultradns.UltraDNS.Record;
 import static denominator.common.Preconditions.checkState;
 import static denominator.common.Util.singletonIterator;
 
+/**
+ * @deprecated UltraDNS SOAP API is close to EOL (End of Life),
+ * use {@link denominator.ultradns.service.UltraDNSRestZoneApi} instead.
+ *
+ * <p>
+ * UltraDNS-REST provider details :
+ * <ul>
+ * <li>Provider name : ultradnsrest</li>
+ * <li>URL : https://restapi.ultradns.com/v2</li>
+ * </ul>
+ */
+@Deprecated
 public final class UltraDNSZoneApi implements denominator.ZoneApi {
 
   private final UltraDNS api;


### PR DESCRIPTION
- Marked all the SOAP API interfaces/classes as deprecated & in the javadoc for UltraDNS-SOAP module
- Modified few existing commit messages in UltraDNS-REST module

@Kushalraj-Bhandari Please check & proceed with merging.
@devulapalli8 FYI